### PR TITLE
Remove max_size parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Usage Example
     display = HX8357(display_bus, width=480, height=320)
 
     # Make the display context
-    splash = displayio.Group(max_size=10)
+    splash = displayio.Group()
     display.show(splash)
 
     color_bitmap = displayio.Bitmap(480, 320, 1)

--- a/examples/hx8357_pitft_simpletest.py
+++ b/examples/hx8357_pitft_simpletest.py
@@ -24,7 +24,7 @@ display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 display = HX8357(display_bus, width=480, height=320)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(display.width, display.height, 1)
@@ -42,7 +42,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=3, x=137, y=160)
+text_group = displayio.Group(scale=3, x=137, y=160)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling

--- a/examples/hx8357_simpletest.py
+++ b/examples/hx8357_simpletest.py
@@ -24,7 +24,7 @@ display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
 display = HX8357(display_bus, width=480, height=320)
 
 # Make the display context
-splash = displayio.Group(max_size=10)
+splash = displayio.Group()
 display.show(splash)
 
 color_bitmap = displayio.Bitmap(480, 320, 1)
@@ -42,7 +42,7 @@ inner_sprite = displayio.TileGrid(inner_bitmap, pixel_shader=inner_palette, x=20
 splash.append(inner_sprite)
 
 # Draw a label
-text_group = displayio.Group(max_size=10, scale=3, x=137, y=160)
+text_group = displayio.Group(scale=3, x=137, y=160)
 text = "Hello World!"
 text_area = label.Label(terminalio.FONT, text=text, color=0xFFFF00)
 text_group.append(text_area)  # Subgroup for text scaling


### PR DESCRIPTION
Remove the `max_size` parameter. It is no longer used by `displayio.Group`
Ref: adafruit/circuitpython#4959

I don't have a HX8357 display to test with.