### PR TITLE
Adjust SETOSC to 0x66 from 0x68 (60/60Hz Normal/Idle mode)

### DIFF
--- a/adafruit_hx8357.py
+++ b/adafruit_hx8357.py
@@ -26,6 +26,9 @@ Implementation Notes
 
 * Adafruit CircuitPython firmware for the supported boards:
   https://github.com/adafruit/circuitpython/releases
+
+** Datasheet:**
+  https://cdn-shop.adafruit.com/datasheets/HX8357-D_DS_April2012.pdf
 """
 
 # imports
@@ -40,7 +43,7 @@ _INIT_SEQUENCE = (
     b"\xB9\x83\xFF\x83\x57\xFF"  # _SETC and delay 500ms
     b"\xB3\x04\x80\x00\x06\x06"  # _SETRGB 0x80 enables SDO pin (0x00 disables)
     b"\xB6\x01\x25"  # _SETCOM -1.52V
-    b"\xB0\x01\x68"  # _SETOSC Normal mode 70Hz, Idle mode 55 Hz
+    b"\xB0\x01\x66"  # _SETOSC Normal mode 60Hz, Idle mode 60 Hz
     b"\xCC\x01\x05"  # _SETPANEL BGR, Gate direction swapped
     b"\xB1\x06\x00\x15\x1C\x1C\x83\xAA"  # _SETPWR1 Not deep standby BT VSPR VSNR AP
     b"\xC0\x06\x50\x50\x01\x3C\x1E\x08"  # _SETSTBA OPON normal OPON idle STBA GEN


### PR DESCRIPTION
This addresses spurious multiple touches experienced with the batch of 3.5" touchscreens with the silkscreen misspelling of Capacitive as "Capaciptive".

There's a forum post showing a possible fix along with others experiencing the issue: https://forums.adafruit.com/memberlist.php?mode=viewprofile&u=220642

This datasheet page shows the calculation for internal touch oscillator frequency during Normal Mode and Idle Mode:

![image](https://github.com/adafruit/Adafruit_CircuitPython_HX8357/assets/6692083/dfc6a787-a343-4920-bf2b-ae5dbfccb86d)

The original code uses some values that don't match the code comment either:
![image](https://github.com/adafruit/Adafruit_CircuitPython_HX8357/assets/6692083/712c06cf-a6df-40d8-b577-f743ffb86805)

I've set both to 60Hz (only really adjusting normal mode) 

There's an interest from the wider world to understand why 70Hz was chosen,  if someone knows then stick it in the forum and help grow the understanding.