### PR TITLE
Update HX8357 driver to 8.x/9.x transitional code

### DIFF
--- a/adafruit_hx8357.py
+++ b/adafruit_hx8357.py
@@ -29,7 +29,7 @@ Implementation Notes
 """
 
 # imports
-# Support both 8.x.x and 9.x.x. Removed 8.x method when discontinued.
+# Support both 8.x.x and 9.x.x. Remove 8.x method when discontinued.
 try:
     from fourwire import FourWire  # 9.x method
     from busdisplay import BusDisplay
@@ -66,5 +66,5 @@ _INIT_SEQUENCE = (
 class HX8357(BusDisplay):
     """HX8357D driver"""
 
-    def __init__(self, bus: FourWire.FourWire, **kwargs) -> None:
+    def __init__(self, bus: FourWire, **kwargs) -> None:
         super().__init__(bus, _INIT_SEQUENCE, **kwargs)

--- a/adafruit_hx8357.py
+++ b/adafruit_hx8357.py
@@ -30,7 +30,19 @@ Implementation Notes
 
 # imports
 
-import displayio
+try:
+    # used for typing only
+    from typing import Any
+except ImportError:
+    pass
+
+# Support both 8.x.x and 9.x.x. Change when 8.x.x is discontinued as a stable release.
+try:
+    from fourwire import FourWire  # 9.x method
+    from busdisplay import BusDisplay
+except ImportError:
+    from displayio import FourWire  # 8.x method
+    from displayio import Display as BusDisplay
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_HX8357.git"
@@ -58,8 +70,8 @@ _INIT_SEQUENCE = (
 
 
 # pylint: disable=too-few-public-methods
-class HX8357(displayio.Display):
+class HX8357(BusDisplay):
     """HX8357D driver"""
 
-    def __init__(self, bus: displayio.FourWire, **kwargs) -> None:
+    def __init__(self, bus: FourWire.FourWire, **kwargs) -> None:
         super().__init__(bus, _INIT_SEQUENCE, **kwargs)

--- a/adafruit_hx8357.py
+++ b/adafruit_hx8357.py
@@ -29,14 +29,7 @@ Implementation Notes
 """
 
 # imports
-
-try:
-    # used for typing only
-    from typing import Any
-except ImportError:
-    pass
-
-# Support both 8.x.x and 9.x.x. Change when 8.x.x is discontinued as a stable release.
+# Support both 8.x.x and 9.x.x. Removed 8.x method when discontinued.
 try:
     from fourwire import FourWire  # 9.x method
     from busdisplay import BusDisplay


### PR DESCRIPTION
3.5" TFT Featherwing display driver needs updating for 9.0.  Added 8.x to 9.x transitional code so it should work in either 8.x or 9.x  Only tested in 9.x, needs 8.x testing.  In 9.x the previous driver commit would bring up future warnings.

```
FutureWarning: Display moved from displayio to busdisplay
FutureWarning: Display renamed BusDisplay
```
These are now addressed with this commit and no warnings are present while using 9.0