### PR TITLE
9x compatibility in examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,14 @@ Usage Example
 
     import board
     import displayio
+
+    # Compatibility with both CircuitPython 8.x.x and 9.x.x.
+    # Remove after 8.x.x is no longer a supported release.
+    try:
+        from fourwire import FourWire
+    except ImportError:
+        from displayio import FourWire
+
     from adafruit_hx8357 import HX8357
 
     spi = board.SPI()
@@ -44,7 +52,7 @@ Usage Example
     tft_dc = board.D10
 
     displayio.release_displays()
-    display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
+    display_bus = FourWire(spi, command=tft_dc, chip_select=tft_cs)
 
     display = HX8357(display_bus, width=480, height=320)
 

--- a/examples/hx8357_pitft_simpletest.py
+++ b/examples/hx8357_pitft_simpletest.py
@@ -9,6 +9,14 @@ background, a smaller purple rectangle, and some yellow text.
 import board
 import terminalio
 import displayio
+
+# Compatibility with both CircuitPython 8.x.x and 9.x.x.
+# Remove after 8.x.x is no longer a supported release.
+try:
+    from fourwire import FourWire
+except ImportError:
+    from displayio import FourWire
+
 from adafruit_display_text import label
 from adafruit_hx8357 import HX8357
 
@@ -19,7 +27,7 @@ spi = board.SPI()
 tft_cs = board.CE0
 tft_dc = board.D25
 
-display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
+display_bus = FourWire(spi, command=tft_dc, chip_select=tft_cs)
 
 display = HX8357(display_bus, width=480, height=320)
 

--- a/examples/hx8357_simpletest.py
+++ b/examples/hx8357_simpletest.py
@@ -9,6 +9,14 @@ background, a smaller purple rectangle, and some yellow text.
 import board
 import terminalio
 import displayio
+
+# Compatibility with both CircuitPython 8.x.x and 9.x.x.
+# Remove after 8.x.x is no longer a supported release.
+try:
+    from fourwire import FourWire
+except ImportError:
+    from displayio import FourWire
+
 from adafruit_display_text import label
 from adafruit_hx8357 import HX8357
 
@@ -19,7 +27,7 @@ spi = board.SPI()
 tft_cs = board.D9
 tft_dc = board.D10
 
-display_bus = displayio.FourWire(spi, command=tft_dc, chip_select=tft_cs)
+display_bus = FourWire(spi, command=tft_dc, chip_select=tft_cs)
 
 display = HX8357(display_bus, width=480, height=320)
 


### PR DESCRIPTION
Main library was updated previously but examples are still 8x style.